### PR TITLE
Change logic to if/else and undefined to null

### DIFF
--- a/jsfiddle_save_shortcut_userscript.js
+++ b/jsfiddle_save_shortcut_userscript.js
@@ -1,5 +1,6 @@
 /**
  * Created by p.querner on 22.01.2015.
+ * Edit by jemiloii on 22.01.2015
  */
 // ==UserScript==
 // @name       My Fancy New Userscript
@@ -15,10 +16,9 @@
 // ==/UserScript==
 
 Mousetrap.bindGlobal(['command+s', 'ctrl+s'], function() {
-    if(document.getElementById('update') != undefined) { //Update found
+    if(document.getElementById('update') !== null) { //Update found
         document.getElementById('update').click(); //Emulate click
-    }
-    if(document.getElementById('savenew') != undefined) { //Savenew found
+    }else{
         document.getElementById('savenew').click(); //Emulate click
     }
     // return false to prevent default browser behavior


### PR DESCRIPTION
Needed a else logic because after the update button is created, jsfiddle simply hides the save button rather than destroying it. Fiddle has a lot of sloppiness, but its an easy work around. When an element isn't found, it'll return null in chrome.
